### PR TITLE
Properly handle OpenAI JSON error responses when expecting stream response

### DIFF
--- a/langchain/src/util/axios-fetch-adapter.js
+++ b/langchain/src/util/axios-fetch-adapter.js
@@ -250,6 +250,16 @@ async function getResponse(request, config) {
     if (config.responseType === "stream") {
       const contentType = stageOne.headers.get("content-type");
       if (!contentType?.startsWith(EventStreamContentType)) {
+        if (contentType?.startsWith('application/json')) {
+          // If the response is JSON, try to parse it and throw a more specific error
+          response.data = await stageOne.json();
+          if (response.data?.error instanceof Error) {
+            throw response.data.error;
+          }
+          throw new Error(
+              `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}. Error: ${response.data?.error?.message}`
+          );
+        }
         throw new Error(
           `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`
         );


### PR DESCRIPTION
OpenAI returns `application/json` content-type for errors even when expecting a stream in cases like token limit error or other openai related errors. Right now, `axios-fetch-adapter.js:getResponse` only throws a very generic error message, making it impossible to understand what the actual problem is.

```js
        // This is very generic and makes it impossible to understand the real error.
        throw new Error(
          `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`
        );
```

My fix gets the json body and if there is a proper Error object found inside, throws the real error, making it possible to debug or notify users in such cases.

This issue also seems to be about the same problem: #670